### PR TITLE
Add start and build scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,8 @@
 {
+  "scripts": {
+    "start": "gulp watch",
+    "build": "gulp"
+  },
   "devDependencies": {
     "@babel/core": "^7.28.0",
     "@babel/preset-env": "^7.28.0",


### PR DESCRIPTION
## Summary
- define start and build scripts in `package.json`

## Testing
- `npm run build` *(fails: gulp not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876879b39e0833299e97af1441ff66b