### PR TITLE
Fix scp action reference

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
         run: npx gulp
 
       - name: 🚀 Deploy to Server via SCP
-        uses: appleboy/scp-action@master
+        uses: appleboy/scp-action@v0.1.4
         with:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USER }}


### PR DESCRIPTION
## Summary
- use tagged release `v0.1.4` for appleboy/scp-action in deploy workflow

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687687b5b6308332beb7ef5d1bc468bf