### PR TITLE
Fix watchers for HTML and fonts

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -153,8 +153,8 @@ function watchFiles() {
   gulp
     .watch(paths.images.src, gulp.series(images, webpImages))
     .on("change", browserSync.reload);
-  gulp.watch(paths.fonts.src, fonts);
-  gulp.watch("./app/*.html", html).on("change", browserSync.reload);
+  gulp.watch(paths.fonts.src, fonts).on("change", browserSync.reload);
+  gulp.watch(paths.html.src, html).on("change", browserSync.reload);
 }
 
 const finalNotify = (done) => {


### PR DESCRIPTION
## Summary
- use path constants for the HTML watch pattern
- reload BrowserSync when fonts change

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_687687cbcc748332a612e3fbe269b0dd