### PR TITLE
Fix .gitignore to track package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,6 @@ ehthumbs.db
 .vscode/
 
 # Optional lock files (if using npm or yarn exclusively)
-package-lock.json
 yarn.lock
 
 # Cache


### PR DESCRIPTION
## Summary
- keep `package-lock.json` under version control
- remove `package-lock.json` entry from `.gitignore`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68778aa6ea84833297ba508d571d9443