### PR TITLE
Lock yargs-parser to 21.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2,6 +2,9 @@
   "name": "DRILLCOLTD-website",
   "lockfileVersion": 3,
   "requires": true,
+  "overrides": {
+    "yargs-parser": "21.1.1"
+  },
   "packages": {
     "": {
       "devDependencies": {
@@ -6143,12 +6146,12 @@
       }
     },
     "node_modules/gulp-cli/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/gulp-concat": {
@@ -12967,12 +12970,12 @@
       }
     },
     "node_modules/yargs-parser": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
-      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
+        "node": ">=12"
       }
     },
     "node_modules/yargs/node_modules/yargs-parser": {

--- a/package.json
+++ b/package.json
@@ -26,5 +26,11 @@
     "gulp-terser": "^2.1.0",
     "gulp-webp": "^4.0.1",
     "sass": "^1.89.2"
+  },
+  "engines": {
+    "node": ">=18.6.0"
+  },
+  "overrides": {
+    "yargs-parser": "21.1.1"
   }
 }


### PR DESCRIPTION
## Summary
- pin `yargs-parser` via `overrides`
- require Node 18.6.0 or newer
- regenerate `package-lock.json` with the override

## Testing
- `mise exec node@18.6.0 -- npm run build` *(fails: gulp not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877b3d840fc8332978cd03ef921c44b