### PR TITLE
Add basic package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "name": "drillcoltd-website",
+  "version": "0.1.0",
+  "private": true,
   "scripts": {
     "start": "gulp watch",
     "build": "gulp",


### PR DESCRIPTION
## Summary
- insert `name`, `version`, and `private` fields at the start of `package.json` to remove npm metadata warnings

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6877c5ca6ff483329fa1df19089b9427