### PR TITLE
Remove MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,5 @@
+Copyright (c) 2025 Nemanja Bojovic
+
+All rights reserved. This software is proprietary and confidential. No
+permission is granted to copy, distribute, or modify any part of this
+codebase without explicit written consent from the copyright holder.

--- a/README.md
+++ b/README.md
@@ -152,4 +152,4 @@ If network access is restricted, `npm install` may fail with `ECONNRESET`.
 
 ## 📜 License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is proprietary. All rights reserved. See the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
## Summary
- drop MIT license and replace with proprietary notice
- README updated to note project is proprietary

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687b919dc6e88332bb725f298d367138