### PR TITLE
Add ?cb=0 placeholders for cache busting

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ Outputs an optimized, cache-busted build in the `/build` folder:
 - Purged unused styles with **PurgeCSS**
 - Optimized images (JPEG/PNG/WebP)
 - Final HTML with cache-busting
+- Asset links in `app/index.html` include a `?cb=0` placeholder that Gulp
+  replaces with a timestamp during the build to ensure browsers fetch the
+  latest files.
 
 ---
 

--- a/app/index.html
+++ b/app/index.html
@@ -4,10 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <!-- Styles -->
-    <link rel="stylesheet" href="assets/css/styles.min.css" />
+    <link rel="stylesheet" href="assets/css/styles.min.css?cb=0" />
 
     <!-- Favicon -->
-    <link href="favicon.ico" rel="icon" type="image/x-icon" />
+    <link href="favicon.ico?cb=0" rel="icon" type="image/x-icon" />
     <!-- Title -->
     <title>DRILL WEED SHOP</title>
   </head>
@@ -78,7 +78,7 @@
     <!-- <footer class="footer"></footer> -->
 
     <!-- Scripts -->
-    <script src="assets/js/vendors.min.js"></script>
-    <script src="assets/js/app.min.js"></script>
+    <script src="assets/js/vendors.min.js?cb=0"></script>
+    <script src="assets/js/app.min.js?cb=0"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add `?cb=0` query string to CSS, JS and favicon references in `app/index.html`
- document cache-busting placeholders in README

## Testing
- `git status --porcelain`

------
https://chatgpt.com/codex/tasks/task_e_687b9e8977308332b190d26aa5b9515c