### PR TITLE
Clarify Node 18.6.0 usage with nvm

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ Installs all required development dependencies.
 
 > **Note**: Development expects **Node.js 18.6.0**. An `.nvmrc` file is provided for use with [nvm](https://github.com/nvm-sh/nvm) or a similar manager.
 
+### 📌 Node Version via nvm
+
+If you have [nvm](https://github.com/nvm-sh/nvm) installed, run the following commands before starting development. They ensure you are using Node **18.6.0** as defined in `.nvmrc`:
+
+```bash
+nvm install 18.6.0
+nvm use 18.6.0
+```
+
 ---
 
 ### 🧪 Development


### PR DESCRIPTION
## Summary
- specify Node 18.6.0 in nvm install and use instructions

## Testing
- `node --version`
- `nvm --version`


------
https://chatgpt.com/codex/tasks/task_e_687bb86a07ac83328e4c452ecca689ef