### PR TITLE
chore: simplify ESLint globals import

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,8 +1,6 @@
 import js from "@eslint/js";
 import globals from "globals";
 
-const { browser, node } = globals;
-
 export default [
   js.configs.recommended,
   {
@@ -10,8 +8,8 @@ export default [
       ecmaVersion: "latest",
       sourceType: "module",
       globals: {
-        ...browser,
-        ...node,
+        ...globals.browser,
+        ...globals.node,
       },
     },
     rules: {},


### PR DESCRIPTION
## Summary
- refactor ESLint flat config to import browser and node globals directly

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint:js`
- `npm run lint:scss`


------
https://chatgpt.com/codex/tasks/task_e_68a12493b74483328263d8bb2394a388