### PR TITLE
build: simplify vendors task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -106,8 +106,6 @@ const vendors = () =>
     .src(paths.vendors.src)
     .pipe(plumber({ errorHandler }))
     .pipe(sourcemaps.init())
-    .pipe(babel({ presets: ["@babel/preset-env"] }))
-    .pipe(terser())
     .pipe(concat("vendors.min.js"))
     .pipe(sourcemaps.write("."))
     .pipe(gulp.dest(paths.vendors.dest));


### PR DESCRIPTION
## Summary
- simplify `vendors` gulp task to only concatenate vendor scripts

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint:js`
- `npm run lint:scss`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a131318af08332b041e8f6a193ab11