### PR TITLE
Improve slider accessibility and form UX

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -54,17 +54,25 @@
           </p>
         </div>
         <section class="slider-section">
-          <div id="main-slider" class="splide">
+          <div id="main-slider" class="splide" aria-label="Main slider">
             <div class="splide__track">
               <ul class="splide__list">
                 <li class="splide__slide">
                   <img src="assets/images/header-bg.jpg" alt="Slide 1" />
                 </li>
                 <li class="splide__slide">
-                  <img src="assets/images/header-bg.jpg" alt="Slide 2" />
+                  <img
+                    src="assets/images/header-bg.jpg"
+                    alt="Slide 2"
+                    loading="lazy"
+                  />
                 </li>
                 <li class="splide__slide">
-                  <img src="assets/images/header-bg.jpg" alt="Slide 3" />
+                  <img
+                    src="assets/images/header-bg.jpg"
+                    alt="Slide 3"
+                    loading="lazy"
+                  />
                 </li>
               </ul>
             </div>
@@ -100,15 +108,18 @@
                 class="contact-form__input"
                 id="email"
                 placeholder="you@example.com"
+                autocomplete="email"
                 required
               />
             </div>
-            <div aria-hidden="true" style="position: absolute; left: -5000px">
+            <div style="position: absolute; left: -5000px">
+              <label for="hp">Leave this field empty</label>
               <input
                 type="text"
                 name="b_aed9060ebda59851e1a51a45d_448f502d04"
                 tabindex="-1"
                 value=""
+                id="hp"
               />
             </div>
             <button type="submit" class="contact-form__button">

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -4,6 +4,11 @@
 document.addEventListener('DOMContentLoaded', () => {
   const slider = document.querySelector('#main-slider');
   if (slider) {
-    new Splide(slider, { type: 'loop', autoplay: true }).mount();
+    new Splide(slider, {
+      type: 'loop',
+      autoplay: true,
+      arrows: false,
+      pagination: false,
+    }).mount();
   }
 });

--- a/app/scss/pages/_index.scss
+++ b/app/scss/pages/_index.scss
@@ -27,7 +27,7 @@ header.header {
     left: 0;
     width: 100%;
     height: 100%;
-    background-color: rgb(black, 0.5);
+    background-color: rgb(0 0 0 / 50%);
     z-index: 0;
   }
 
@@ -70,9 +70,9 @@ header.header {
 
   .sub_heading {
     color: white;
-    font-size: 1.8rem;
+    font-size: clamp(1.2rem, 4vw, 1.8rem);
     margin-top: 1rem;
-    text-shadow: 0 1px 3px rgb(black, 0.7);
+    text-shadow: 0 1px 3px rgb(0 0 0 / 70%);
     max-width: 35rem;
     font-weight: 400;
     text-align: center;
@@ -95,6 +95,10 @@ header.header {
       border-radius: 8px;
       overflow: hidden;
       box-shadow: 0 10px 30px rgb(0 0 0 / 30%);
+    }
+
+    .splide__track {
+      aspect-ratio: 16/9;
     }
 
     .splide__slide img {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -105,9 +105,7 @@ const vendors = () =>
   gulp
     .src(paths.vendors.src)
     .pipe(plumber({ errorHandler }))
-    .pipe(sourcemaps.init())
     .pipe(concat("vendors.min.js"))
-    .pipe(sourcemaps.write("."))
     .pipe(gulp.dest(paths.vendors.dest));
 
 const images = async (done) => {


### PR DESCRIPTION
## Summary
- Disable Splide arrows and pagination while adding `aria-label` and lazy-loading to slider images
- Enhance form experience with email autocomplete and an accessible honeypot field
- Simplify vendor build pipeline and reserve slider height to reduce layout shift

## Testing
- `npm run lint:js`
- `npm run lint:scss`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1331644e48332814349c030be9381