### PR TITLE
Copy Splide CSS into build and reference directly

### DIFF
--- a/app/contact.html
+++ b/app/contact.html
@@ -12,6 +12,7 @@
 
       gtag('config', 'G-FPYSB5CEGQ');
     </script>
+    <link rel="stylesheet" href="assets/css/splide.min.css?cb=0" />
     <link rel="stylesheet" href="assets/css/styles.min.css?cb=0" />
     <link href="favicon.ico?cb=0" rel="icon" type="image/x-icon" />
     <title>Contact - DRILL WEED SHOP</title>

--- a/app/index.html
+++ b/app/index.html
@@ -18,6 +18,7 @@
       gtag("config", "G-FPYSB5CEGQ");
     </script>
     <!-- Styles -->
+    <link rel="stylesheet" href="assets/css/splide.min.css?cb=0" />
     <link rel="stylesheet" href="assets/css/styles.min.css?cb=0" />
 
     <!-- Favicon -->

--- a/app/scss/main.scss
+++ b/app/scss/main.scss
@@ -1,4 +1,3 @@
 @use "./abstracts/all" as *;
 @use "./base/all" as *;
 @use "./pages/all" as *;
-@import "@splidejs/splide/dist/css/splide.min.css";

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,6 +24,10 @@ const { globSync } = require("glob");
 const paths = {
   html: { src: "./app/**/*.html", dest: "./build" },
   styles: { src: "./app/scss/main.scss", dest: "./build/assets/css" },
+  vendorStyles: {
+    src: "./node_modules/@splidejs/splide/dist/css/splide.min.css",
+    dest: "./build/assets/css",
+  },
   scripts: { src: "./app/js/*.js", dest: "./build/assets/js" },
   vendors: {
     src: [
@@ -159,6 +163,7 @@ const createCopyTask = (taskName, pathsConfig) => (done) => {
 
 const videos = createCopyTask("videos", paths.videos);
 const fonts = createCopyTask("fonts", paths.fonts);
+const vendorStyles = createCopyTask("vendor styles", paths.vendorStyles);
 
 const favicon = () =>
   gulp.src(paths.favicon.src).pipe(gulp.dest(paths.favicon.dest));
@@ -198,6 +203,7 @@ const build = gulp.series(
   clean,
   gulp.parallel(
     html,
+    vendorStyles,
     styles,
     vendors,
     scripts,
@@ -223,6 +229,7 @@ exports.videos = videos;
 exports.fonts = fonts;
 exports.favicon = favicon;
 exports.html = html;
+exports.vendorStyles = vendorStyles;
 exports.cacheBust = cacheBust;
 exports.watch = watch;
 exports.build = build;


### PR DESCRIPTION
## Summary
- Remove runtime @import of Splide's stylesheet from main Sass entry
- Copy Splide CSS into build via new Gulp vendorStyles task
- Link Splide CSS before main styles in HTML

## Testing
- `npm run lint:js`
- `npm run lint:scss`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a1349c54148332984b90122c3b1e16