### PR TITLE
Add About, Privacy, and Terms pages with styles

### DIFF
--- a/app/about.html
+++ b/app/about.html
@@ -20,7 +20,7 @@
     <link rel="stylesheet" href="assets/css/splide.min.css?cb=0" />
     <link rel="stylesheet" href="assets/css/styles.min.css?cb=0" />
     <link href="favicon.ico?cb=0" rel="icon" type="image/x-icon" />
-    <title>Contact - DRILL WEED SHOP</title>
+    <title>About - DRILL WEED SHOP</title>
   </head>
   <body>
     <header class="header">
@@ -48,7 +48,21 @@
       </nav>
     </header>
 
-    <main class="main"></main>
+    <main class="main about-page">
+      <h1>About Drill Weed Shop</h1>
+      <p>
+        Founded in 2020, Drill Weed Shop started as a small crew of
+        enthusiasts determined to engineer the cleanest, loudest flower on
+        the island. What began as a passion project has grown into a trusted
+        source for connoisseurs seeking premium cannabis.
+      </p>
+      <p>
+        Our mission is simple: fuse innovation with tradition and deliver
+        products that light up the senses while respecting the plant. We
+        believe in quality, transparency and blazing new trails—responsibly
+        and sustainably.
+      </p>
+    </main>
 
     <!-- footer -->
     <footer class="site-footer" id="footer">

--- a/app/index.html
+++ b/app/index.html
@@ -37,7 +37,16 @@
               <a href="/" class="navbar__link">Home</a>
             </li>
             <li class="navbar__item">
+              <a href="/about.html" class="navbar__link">About</a>
+            </li>
+            <li class="navbar__item">
               <a href="/contact.html" class="navbar__link">Contact</a>
+            </li>
+            <li class="navbar__item">
+              <a href="/privacy.html" class="navbar__link">Privacy</a>
+            </li>
+            <li class="navbar__item">
+              <a href="/terms.html" class="navbar__link">Terms</a>
             </li>
           </ul>
         </div>

--- a/app/privacy.html
+++ b/app/privacy.html
@@ -20,7 +20,7 @@
     <link rel="stylesheet" href="assets/css/splide.min.css?cb=0" />
     <link rel="stylesheet" href="assets/css/styles.min.css?cb=0" />
     <link href="favicon.ico?cb=0" rel="icon" type="image/x-icon" />
-    <title>Contact - DRILL WEED SHOP</title>
+    <title>Privacy Policy - DRILL WEED SHOP</title>
   </head>
   <body>
     <header class="header">
@@ -48,7 +48,23 @@
       </nav>
     </header>
 
-    <main class="main"></main>
+    <main class="main privacy-page">
+      <h1>Privacy Policy</h1>
+      <p>
+        Your privacy matters to us. This policy explains how Drill Weed Shop
+        collects, uses and safeguards your information when you visit our
+        website or interact with our services.
+      </p>
+      <p>
+        We collect only the data necessary to process orders and improve the
+        customer experience. We never sell personal information, and you can
+        request its removal at any time.
+      </p>
+      <p>
+        By using this site you agree to the practices described here. Any
+        updates to this policy will be posted on this page.
+      </p>
+    </main>
 
     <!-- footer -->
     <footer class="site-footer" id="footer">

--- a/app/scss/pages/_about.scss
+++ b/app/scss/pages/_about.scss
@@ -1,0 +1,22 @@
+@use "../abstracts/all" as *;
+
+.about-page {
+  padding: 4.5rem 2rem;
+  max-width: 800px;
+  margin-inline: auto;
+
+  h1 {
+    @include heading-typo;
+
+    color: #{palette($palette, primary, main)};
+    margin-bottom: val($space, lg);
+  }
+
+  p {
+    @include text-typo;
+
+    line-height: 1.6;
+    margin-bottom: val($space, md);
+  }
+}
+

--- a/app/scss/pages/_all.scss
+++ b/app/scss/pages/_all.scss
@@ -1,2 +1,5 @@
 @forward "index";
 @forward "global";
+@forward "about";
+@forward "privacy";
+@forward "terms";

--- a/app/scss/pages/_privacy.scss
+++ b/app/scss/pages/_privacy.scss
@@ -1,0 +1,22 @@
+@use "../abstracts/all" as *;
+
+.privacy-page {
+  padding: 4.5rem 2rem;
+  max-width: 800px;
+  margin-inline: auto;
+
+  h1 {
+    @include heading-typo;
+
+    color: #{palette($palette, primary, main)};
+    margin-bottom: val($space, lg);
+  }
+
+  p {
+    @include text-typo;
+
+    line-height: 1.6;
+    margin-bottom: val($space, md);
+  }
+}
+

--- a/app/scss/pages/_terms.scss
+++ b/app/scss/pages/_terms.scss
@@ -1,0 +1,22 @@
+@use "../abstracts/all" as *;
+
+.terms-page {
+  padding: 4.5rem 2rem;
+  max-width: 800px;
+  margin-inline: auto;
+
+  h1 {
+    @include heading-typo;
+
+    color: #{palette($palette, secondary, main)};
+    margin-bottom: val($space, lg);
+  }
+
+  p {
+    @include text-typo;
+
+    line-height: 1.6;
+    margin-bottom: val($space, md);
+  }
+}
+

--- a/app/terms.html
+++ b/app/terms.html
@@ -20,7 +20,7 @@
     <link rel="stylesheet" href="assets/css/splide.min.css?cb=0" />
     <link rel="stylesheet" href="assets/css/styles.min.css?cb=0" />
     <link href="favicon.ico?cb=0" rel="icon" type="image/x-icon" />
-    <title>Contact - DRILL WEED SHOP</title>
+    <title>Terms &amp; Conditions - DRILL WEED SHOP</title>
   </head>
   <body>
     <header class="header">
@@ -48,7 +48,23 @@
       </nav>
     </header>
 
-    <main class="main"></main>
+    <main class="main terms-page">
+      <h1>Terms &amp; Conditions</h1>
+      <p>
+        By accessing or purchasing from Drill Weed Shop you agree to comply
+        with the following terms and all applicable laws. You must be at least
+        21 years old to use this site or buy any products.
+      </p>
+      <p>
+        All products are intended for personal use only. Resale or
+        redistribution without written consent is prohibited. We reserve the
+        right to refuse service to anyone violating these terms.
+      </p>
+      <p>
+        These terms may be updated from time to time. Continued use of the
+        site signifies acceptance of the most current version.
+      </p>
+    </main>
 
     <!-- footer -->
     <footer class="site-footer" id="footer">


### PR DESCRIPTION
## Summary
- add About page with company history and mission
- add Privacy Policy and Terms & Conditions pages
- create SCSS partials for each page and expose them via `pages/_all.scss`
- update header navigation to link to new pages

## Testing
- `npm run lint:scss`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68a51a5867388332aca0ec595f4bc0e8