### PR TITLE
style: refine page typography

### DIFF
--- a/app/scss/abstracts/_variables.scss
+++ b/app/scss/abstracts/_variables.scss
@@ -78,25 +78,25 @@ $space: (
 // TYPE SCALING
 $type-scale: (
   h1: (
-    min: 2.8rem,
-    max: 4.2rem,
+    min: 3rem,
+    max: 4.4rem,
   ),
   h2: (
-    min: 2.2rem,
-    max: 3.2rem,
+    min: 2.4rem,
+    max: 3.4rem,
   ),
   lead: (
-    min: 1.4rem,
-    max: 2rem,
+    min: 1.5rem,
+    max: 2.1rem,
   ),
   brand: (
     // NEW: navbar logo
-    min: 1.6rem,
-    max: 2.2rem,
+    min: 1.7rem,
+    max: 2.3rem,
   ),
   nav-link: (
     // NEW: navbar links
-    min: 1.1rem,
-    max: 1.3rem,
+    min: 1.2rem,
+    max: 1.4rem,
   ),
 );

--- a/app/scss/pages/_about.scss
+++ b/app/scss/pages/_about.scss
@@ -13,6 +13,7 @@
 
   h1 {
     @include heading-typo;
+    @include type-scale(h1);
 
     margin: 0 0 val($space, lg);
     color: #{palette($palette, primary, main)};
@@ -20,6 +21,7 @@
 
   p {
     @include text-typo;
+    @include type-scale(lead);
 
     line-height: 1.6;
     margin: 0 0 val($space, md);

--- a/app/scss/pages/_privacy.scss
+++ b/app/scss/pages/_privacy.scss
@@ -13,6 +13,7 @@
 
   h1 {
     @include heading-typo;
+    @include type-scale(h1);
 
     margin: 0 0 val($space, lg);
     color: #{palette($palette, primary, main)};
@@ -20,6 +21,7 @@
 
   p {
     @include text-typo;
+    @include type-scale(lead);
 
     line-height: 1.6;
     margin: 0 0 val($space, md);

--- a/app/scss/pages/_terms.scss
+++ b/app/scss/pages/_terms.scss
@@ -13,6 +13,7 @@
 
   h1 {
     @include heading-typo;
+    @include type-scale(h1);
 
     margin: 0 0 val($space, lg);
     color: #{palette($palette, secondary, main)};
@@ -20,6 +21,7 @@
 
   p {
     @include text-typo;
+    @include type-scale(lead);
 
     line-height: 1.6;
     margin: 0 0 val($space, md);


### PR DESCRIPTION
## Summary
- revert global HTML font-size bump to keep REM layout stable
- scale About, Privacy, and Terms page text for better readability

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint:js`
- `npm run lint:scss`


------
https://chatgpt.com/codex/tasks/task_e_68aa3fddaa3483328ff4a084f28e6eec