### PR TITLE
style: refine page typography

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -12,7 +12,7 @@
               alt="DRILL WEED SHOP Logo"
             />
           </h1>
-          <p class="sub_heading">
+          <p class="header__tagline">
             Where Fire Meets Flower. Engineered to Blow Your Mind.
           </p>
         </div>

--- a/app/scss/abstracts/_variables.scss
+++ b/app/scss/abstracts/_variables.scss
@@ -78,25 +78,25 @@ $space: (
 // TYPE SCALING
 $type-scale: (
   h1: (
-    min: 2.8rem,
-    max: 4.2rem,
+    min: 3rem,
+    max: 4.4rem,
   ),
   h2: (
-    min: 2.2rem,
-    max: 3.2rem,
+    min: 2.4rem,
+    max: 3.4rem,
   ),
   lead: (
-    min: 1.4rem,
-    max: 2rem,
+    min: 1.5rem,
+    max: 2.1rem,
   ),
   brand: (
     // NEW: navbar logo
-    min: 1.6rem,
-    max: 2.2rem,
+    min: 1.7rem,
+    max: 2.3rem,
   ),
   nav-link: (
     // NEW: navbar links
-    min: 1.1rem,
-    max: 1.3rem,
+    min: 1.2rem,
+    max: 1.4rem,
   ),
 );

--- a/app/scss/pages/_about.scss
+++ b/app/scss/pages/_about.scss
@@ -13,6 +13,7 @@
 
   h1 {
     @include heading-typo;
+    @include type-scale(h1);
 
     margin: 0 0 val($space, lg);
     color: #{palette($palette, primary, main)};
@@ -20,6 +21,7 @@
 
   p {
     @include text-typo;
+    @include type-scale(lead);
 
     line-height: 1.6;
     margin: 0 0 val($space, md);

--- a/app/scss/pages/_index.scss
+++ b/app/scss/pages/_index.scss
@@ -50,7 +50,7 @@ header.header {
     height: auto;
   }
 
-  .sub_heading {
+  .header__tagline {
     margin-top: 1rem;
     text-shadow: 0 1px 3px rgb(0 0 0 / 70%);
     max-width: 35rem;
@@ -208,11 +208,11 @@ body.page--home .main {
     border-radius: 0.65rem;
     background: rgb(0 0 0 / 55%);
     backdrop-filter: blur(4px);
-    font-size: 0.95rem;
     letter-spacing: 0.5px;
     line-height: 1;
     pointer-events: none;
 
+    @include fluid-font(1rem, 1.15rem);
     @include text-typo;
   }
 
@@ -223,7 +223,6 @@ body.page--home .main {
     border-radius: 0.65rem;
     background: rgb(0 0 0 / 60%);
     backdrop-filter: blur(4px);
-    font-size: 0.7rem;
     letter-spacing: 0.06em;
     line-height: 1;
     font-weight: 600;
@@ -233,6 +232,7 @@ body.page--home .main {
     transition: opacity 0.35s ease, transform 0.35s ease;
     pointer-events: none;
 
+    @include fluid-font(0.8rem, 0.9rem);
     @include text-typo;
   }
 
@@ -465,20 +465,24 @@ body.page--home .main {
   }
 
   &__headline {
-    @include text-typo;
-
     font-weight: 600;
-    font-size: 1.15rem;
     margin: 0;
+
+    @include text-typo;
+    @include fluid-font(1.15rem, 1.3rem);
   }
 
   &__body {
     /* Multi-line clamp with standard + WebKit */
+    line-height: 1.5;
     overflow: hidden;
     display: -webkit-box;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 3;
     line-clamp: 3; /* new spec syntax */
+
+    @include text-typo;
+    @include fluid-font(1rem, 1.1rem);
   }
 
   &__footer {
@@ -579,10 +583,10 @@ body.page--home .main {
   }
 
   &__address {
-    font-size: 1rem;
     line-height: 1.4;
 
     @include text-typo;
+    @include fluid-font(1rem, 1.2rem);
   }
 
   &__copy {
@@ -668,7 +672,8 @@ body.page--home .main {
     background: rgb(0 0 0 / 55%);
     padding: 0.6rem 1rem;
     border-radius: 0.6rem;
-    font-size: 0.9rem;
+
+    @include fluid-font(0.9rem, 1rem);
   }
 
   &__consent {

--- a/app/scss/pages/_privacy.scss
+++ b/app/scss/pages/_privacy.scss
@@ -13,6 +13,7 @@
 
   h1 {
     @include heading-typo;
+    @include type-scale(h1);
 
     margin: 0 0 val($space, lg);
     color: #{palette($palette, primary, main)};
@@ -20,6 +21,7 @@
 
   p {
     @include text-typo;
+    @include type-scale(lead);
 
     line-height: 1.6;
     margin: 0 0 val($space, md);

--- a/app/scss/pages/_terms.scss
+++ b/app/scss/pages/_terms.scss
@@ -13,6 +13,7 @@
 
   h1 {
     @include heading-typo;
+    @include type-scale(h1);
 
     margin: 0 0 val($space, lg);
     color: #{palette($palette, secondary, main)};
@@ -20,6 +21,7 @@
 
   p {
     @include text-typo;
+    @include type-scale(lead);
 
     line-height: 1.6;
     margin: 0 0 val($space, md);


### PR DESCRIPTION
## Summary
- revert global HTML font-size bump to keep REM layout stable
- scale About, Privacy, and Terms page text for better readability
- apply responsive type scale to index page elements for improved legibility

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint:js`
- `npm run lint:scss`


------
https://chatgpt.com/codex/tasks/task_e_68aa3fddaa3483328ff4a084f28e6eec