### PR TITLE
Fix HTML loop and CSP analytics script

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -77,7 +77,7 @@
             >
           </div>
           <div class="featured-strains__grid">
-            @@loop('data/strains.json', 'partials/strain-card.html')
+            @@loop('partials/strain-card.html', 'data/strains.json')
           </div>
         </section>
         <section class="contact-section">

--- a/app/js/gtag.js
+++ b/app/js/gtag.js
@@ -1,0 +1,8 @@
+/* Google Analytics configuration */
+/* global dataLayer */
+window.dataLayer = window.dataLayer || [];
+function gtag() {
+  dataLayer.push(arguments);
+}
+gtag("js", new Date());
+gtag("config", "G-FPYSB5CEGQ");

--- a/app/partials/head.html
+++ b/app/partials/head.html
@@ -6,15 +6,7 @@
     async
     src="https://www.googletagmanager.com/gtag/js?id=G-FPYSB5CEGQ"
   ></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag() {
-      dataLayer.push(arguments);
-    }
-    gtag("js", new Date());
-
-    gtag("config", "G-FPYSB5CEGQ");
-  </script>
+  <script src="assets/js/gtag.min.js?cb=0"></script>
   <link rel="stylesheet" href="assets/css/splide.min.css?cb=0" />
   <link rel="stylesheet" href="assets/css/styles.min.css?cb=0" />
   <link href="favicon.ico?cb=0" rel="icon" type="image/x-icon" />

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,7 +29,8 @@ const paths = {
     src: "./node_modules/@splidejs/splide/dist/css/splide.min.css",
     dest: "./build/assets/css",
   },
-  scripts: { src: "./app/js/*.js", dest: "./build/assets/js" },
+  scripts: { src: ["./app/js/*.js", "!./app/js/gtag.js"], dest: "./build/assets/js" },
+  analytics: { src: "./app/js/gtag.js", dest: "./build/assets/js" },
   vendors: {
     src: [
       "./node_modules/@splidejs/splide/dist/js/splide.min.js",
@@ -113,6 +114,15 @@ const scripts = () =>
     .pipe(concat("app.min.js"))
     .pipe(sourcemaps.write("."))
     .pipe(gulp.dest(paths.scripts.dest));
+
+const analytics = () =>
+  gulp
+    .src(paths.analytics.src)
+    .pipe(plumber({ errorHandler }))
+    .pipe(babel({ presets: ["@babel/preset-env"] }))
+    .pipe(terser())
+    .pipe(rename({ basename: "gtag", suffix: ".min" }))
+    .pipe(gulp.dest(paths.analytics.dest));
 
 const vendors = () =>
   gulp
@@ -241,6 +251,7 @@ function watchFiles() {
   gulp.watch(paths.vendors.src, gulp.series(vendors, reload));
   gulp.watch(paths.favicon.src, gulp.series(favicon, reload));
   gulp.watch(paths.scripts.src, gulp.series(scripts, reload));
+  gulp.watch(paths.analytics.src, gulp.series(analytics, reload));
   gulp.watch(paths.images.src, gulp.series(images, webpImages, reload));
   gulp.watch(paths.videos.src, gulp.series(videos, reload));
   gulp.watch(paths.fonts.src, gulp.series(fonts, reload));
@@ -264,6 +275,7 @@ const build = gulp.series(
     styles,
     vendors,
     scripts,
+    analytics,
     images,
     webpImages,
     videos,
@@ -279,6 +291,7 @@ const watch = gulp.series(build, watchFiles);
 exports.clean = clean;
 exports.styles = styles;
 exports.scripts = scripts;
+exports.analytics = analytics;
 exports.vendors = vendors;
 exports.images = images;
 exports.webpImages = webpImages;


### PR DESCRIPTION
## Summary
- fix reversed @@loop arguments causing html build failure
- move Google Analytics config to external gtag.min.js to satisfy CSP
- add dedicated analytics build task and watch logic

## Testing
- `npm run lint:js`
- `npm run lint:scss`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb231ff1ec8332888f5df5842093e0